### PR TITLE
Added guideline for Axios

### DIFF
--- a/.github/workflows/node-ci.yaml
+++ b/.github/workflows/node-ci.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
         os:
           - ubuntu-latest
           - macos-latest

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # ssrf-req-filter - Prevent SSRF Attacks :shield:
 
-![David](https://img.shields.io/david/y-mehta/ssrf-req-filter?style=for-the-badge) ![npm](https://img.shields.io/npm/v/ssrf-req-filter?style=for-the-badge) ![NPM](https://img.shields.io/npm/l/ssrf-req-filter?style=for-the-badge) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/y-mehta/ssrf-req-filter/Node.js%20CI?style=for-the-badge)
+![npm](https://img.shields.io/npm/v/ssrf-req-filter?style=for-the-badge) ![NPM](https://img.shields.io/npm/l/ssrf-req-filter?style=for-the-badge)
 
 ## Server-Side Request Forgery (SSRF)
+
 SSRF is an attack vector that abuses an application to interact with the internal/external network or the machine itself. One of the enablers for this vector is the mishandling of URLs. [Read More](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
 
 ## Install
+
 `npm install ssrf-req-filter`
 
 ## Usage
+
 - Axios:
+
 ```
 const ssrfFilter = require('ssrf-req-filter');
 const url = 'https://127.0.0.1'
@@ -25,7 +29,9 @@ axios.get(url, {httpAgent: ssrfFilter(url), httpsAgent: ssrfFilter(url)})
       });
 ```
 
+
 - Node-fetch:
+
 ```
 const ssrfFilter = require('ssrf-req-filter');
 const fetch = require("node-fetch");
@@ -40,5 +46,7 @@ fetch(url, {
     console.log(`${error.toString().split('\n')[0]}`);
   });
 ```
+
+*Note: It's recommended to overwrite both httpAgent and httpsAgent in Axios with ssrf-req-filter. Otherwise, SSRF mitigation can be bypassed via cross protocol redirects. Refer to [Doyensec's research](https://blog.doyensec.com/2023/03/16/ssrf-remediation-bypass.html) for more information.*
 
 *Credits*: Implementation inspired By https://github.com/welefen/ssrf-agent

--- a/test/blockUrls.txt
+++ b/test/blockUrls.txt
@@ -18,7 +18,6 @@
   "http://localtest.me",
   "http://customer1.app.localhost.my.company.127.0.0.1.nip.io",
   "http://mail.ebc.apple.com",
-  "http://bugbounty.dod.network",
   "http://spoofed.burpcollaborator.net",
   "http://127.127.127.127",
   "http://127.0.1.3",

--- a/test/blockUrls.txt
+++ b/test/blockUrls.txt
@@ -91,7 +91,6 @@
   "http://3232235521",
   "http://3232235777",
   "http://7147006462",
-  "http://bugbounty.dod.network",
   "http://customer1.app.localhost.my.company.127.0.0.1.nip.io",
   "http://localhost:+11211aaa",
   "http://localhost:00011211aaaa",


### PR DESCRIPTION
Doyensec's research surfaced a risk around bypassing SSRF protection by using cross-protocol redirects in request and Axios. https://blog.doyensec.com/2023/03/16/ssrf-remediation-bypass.html

Mitigation in Axios can be bypassed if users don't overwrite both http/s Agents.